### PR TITLE
Update to v1.0.0 + client side network switching

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "viem": "^0.3.37"
   },
   "peerDependencies": {
-    "0xsequence": ">=0.43.0",
+    "0xsequence": ">=1.0.0",
     "@rainbow-me/rainbowkit": ">=1.0.0",
     "ethers": ">=5.5",
     "wagmi": ">=1.0.0"
   },
   "devDependencies": {
-    "0xsequence": "^0.43.0",
+    "0xsequence": "^1.0.0",
     "@rainbow-me/rainbowkit": "^1.0.1",
     "@types/node": "^18.16.0",
     "esbuild": "^0.17.18",

--- a/package.json
+++ b/package.json
@@ -23,14 +23,12 @@
     "url": "https://github.com/0xsequence/rainbowkit-plugin/issues"
   },
   "homepage": "https://github.com/0xsequence/rainbowkit-plugin#readme",
-  "dependencies": {
-    "viem": "^0.3.37"
-  },
   "peerDependencies": {
     "0xsequence": ">=1.0.0",
     "@rainbow-me/rainbowkit": ">=1.0.0",
     "ethers": ">=5.5",
-    "wagmi": ">=1.0.0"
+    "wagmi": ">=1.0.0",
+    "viem": ">=0.3.37"
   },
   "devDependencies": {
     "0xsequence": "^1.0.0",
@@ -46,6 +44,7 @@
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^4.8.4",
+    "viem": "^1.2.14",
     "wagmi": "^1.0.8"
   }
 }

--- a/src/sequence-connector.ts
+++ b/src/sequence-connector.ts
@@ -1,67 +1,109 @@
-import { sequence } from '0xsequence';
-import { mainnetNetworks, testnetNetworks } from '@0xsequence/network';
-import type { ConnectOptions, Web3Provider } from '@0xsequence/provider';
-import { Wallet } from '@0xsequence/provider';
-import { Chain } from '@rainbow-me/rainbowkit';
+import { sequence } from '0xsequence'
+import type { ConnectOptions, Web3Provider } from '@0xsequence/provider'
+import { Wallet } from '@0xsequence/provider'
+import { Chain } from '@rainbow-me/rainbowkit'
+
 import {
   createWalletClient,
   custom,
   UserRejectedRequestError
 } from 'viem'
-import { Connector, ConnectorData, ConnectorNotFoundError } from 'wagmi';
+
+import { Connector, ConnectorData, ConnectorNotFoundError } from 'wagmi'
 
 interface Options {
-  connect?: ConnectOptions;
+  connect?: ConnectOptions
+}
+
+export class SharedChainID {
+  private static chainID: number
+  private static callbacks: ((chainID: number) => void)[] = []
+
+  static onChange(callback: (chainID: number) => void) {
+    this.callbacks.push(callback)
+  }
+
+  static set(chainID: number) {
+    this.chainID = chainID
+    this.callbacks.forEach((cb) => cb(chainID))
+  }
+
+  static get() {
+    return this.chainID
+  }
 }
 
 export class SequenceConnector extends Connector<Web3Provider, Options | undefined> {
-  id = 'sequence';
-  name = 'Sequence';
-  // chains = chainConfigList
-  ready = true;
-  provider: Web3Provider | null = null;
-  wallet?: Wallet;
-  connected = false;
+  id = 'sequence'
+  name = 'Sequence'
+  ready = true
+  provider: Web3Provider | null = null
+  wallet?: Wallet
+  connected = false
+
+  // NOTICE: The chainId is a singleton
+  // this is because rainbowkit expects the whole wallet to switch networks
+  // at once, and we can't avoid rainbowkit from creating multiple connectors
+  // so we mimic the same behavior here.
+  chainId = SharedChainID
+
   constructor({ chains, options }: { chains?: Chain[]; options?: Options }) {
-    super({ chains, options });
+    super({ chains, options })
+
+    if (this.chainId.get() === undefined) {
+      this.chainId.set(chains?.[0]?.id || 1)
+    }
   }
+
   async connect(): Promise<Required<ConnectorData>> {
     if (!this.wallet) {
-      this.wallet = await sequence.initWallet();
+      this.wallet = await sequence.initWallet()
     }
     if (!this.wallet.isConnected()) {
       // @ts-ignore-next-line
       this?.emit('message', { type: 'connecting' })
-      const e = await this.wallet.connect(this.options?.connect);
+      const e = await this.wallet.connect(this.options?.connect)
       if (e.error) {
-        throw new UserRejectedRequestError(new Error(e.error));
+        throw new UserRejectedRequestError(new Error(e.error))
       }
       if (!e.connected) {
-        throw new UserRejectedRequestError(new Error('Wallet connection rejected'));
+        throw new UserRejectedRequestError(new Error('Wallet connection rejected'))
       }
     }
 
-    const chainId = await this.getChainId();
-    const provider = await this.getProvider();
-    const account = await this.getAccount();
-    provider.on("accountsChanged", this.onAccountsChanged);
-    this.wallet.on('chainChanged', this.onChainChanged);
-    provider.on('disconnect', this.onDisconnect);
-    this.connected = true;
+    const chainId = await this.getChainId()
+    const provider = await this.getProvider()
+    const account = await this.getAccount()
+
+    this.chainId.onChange((chainID) => {
+      // @ts-ignore-next-line
+      console.log('chain changed', chainID)
+      this?.emit('change', { chain: { id: chainID, unsupported: false } })
+      this.provider?.emit('chainChanged', chainId)
+    })
+
+    provider.on("accountsChanged", this.onAccountsChanged)
+    provider.on('disconnect', this.onDisconnect)
+
+    this.connected = true
+
     return {
       account,
       chain: {
         id: chainId,
         unsupported: this.isChainUnsupported(chainId),
       },
-    };
+    }
   }
+
   async getWalletClient({ chainId }: { chainId?: number } = {}) {
     const [provider, account] = await Promise.all([
       this.getProvider(),
       this.getAccount(),
     ])
+
     const chain = this.chains.find((x) => x.id === chainId)
+
     if (!provider) throw new Error('provider is required.')
     return createWalletClient({
       account,
@@ -69,86 +111,146 @@ export class SequenceConnector extends Connector<Web3Provider, Options | undefin
       transport: custom(provider),
     })
   }
+
   async disconnect() {
     if (!this.wallet) {
-      this.wallet = await sequence.initWallet();
+      this.wallet = await sequence.initWallet()
     }
-    this.wallet.disconnect();
+    this.wallet.disconnect()
   }
+
   async getAccount() {
     if (!this.wallet) {
-      this.wallet = await sequence.initWallet();
+      this.wallet = await sequence.initWallet()
     }
-    return this.wallet.getAddress() as Promise<`0x${string}`>;
+    return this.wallet.getAddress() as Promise<`0x${string}`>
   }
+
   async getChainId() {
-    if (!this.wallet) {
-      this.wallet = await sequence.initWallet();
-    }
-    // in mobile, when connecting with sequence Rainbowkit first tried to get ChainID for some reason, but in sequence you can't get ChainID before being connected, so forcing here to connect if you want to get ChainID
-    if (!this.wallet.isConnected()) {
-      return this.connect().then(() => {
-        if (!this.wallet) {
-          sequence.initWallet();
-          this.wallet = sequence.getWallet();
-        }
-        return this.wallet.getChainId()
-      });
-    }
-    return this.wallet.getChainId();
+    return this.chainId.get()
   }
+
   async getProvider() {
     if (!this.wallet) {
-      this.wallet = await sequence.initWallet();
+      this.wallet = await sequence.initWallet()
     }
+
     if (!this.provider) {
-      const provider = this.wallet.getProvider();
+      const provider = this.wallet.getProvider()
       if (!provider) {
-        throw new ConnectorNotFoundError('Failed to get Sequence Wallet provider.');
+        throw new ConnectorNotFoundError('Failed to get Sequence Wallet provider.')
       }
-      this.provider = provider;
+      this.provider = this.patchProvider(provider)
     }
-    return this.provider;
+
+    return this.provider
   }
+
   async getSigner() {
     if (!this.wallet) {
-      this.wallet = await sequence.initWallet();
+      this.wallet = await sequence.initWallet()
     }
-    return this.wallet.getSigner();
+    return this.wallet.getSigner()
   }
+
   async isAuthorized() {
     try {
-      const account = await this.getAccount();
-      return !!account;
+      const account = await this.getAccount()
+      return !!account
     } catch {
-      return false;
+      return false
     }
   }
+
   async switchChain(chainId: number): Promise<Chain> {
-    await this.provider?.send('wallet_switchEthereumChain', [{ chainId }]);
-    return { id: chainId } as Chain;
+    if (this.isChainUnsupported(chainId)) {
+      throw new Error('Unsupported chain')
+    }
+
+    this.chainId.set(chainId)
+
+    return { id: chainId } as Chain
   }
+
+  protected onChainChanged(chain: string | number): void {
+    this.chainId.set(normalizeChainId(chain))
+  }
+
   protected onAccountsChanged = (accounts: string[]) => {
-    return { account: accounts[0] };
-  };
-  protected onChainChanged = (chain: number | string) => {
-    this.provider?.emit('chainChanged', chain);
-    const id = normalizeChainId(chain);
-    const unsupported = this.isChainUnsupported(id);
-    // @ts-ignore-next-line
-    this?.emit('change', { chain: { id, unsupported } })
-  };
+    return { account: accounts[0] }
+  }
+
   protected onDisconnect = () => {
     // @ts-ignore-next-line
     this?.emit('disconnect')
-  };
+  }
+
   isChainUnsupported(chainId: number): boolean {
-    return !(mainnetNetworks.some((c) => c.chainId === chainId) || testnetNetworks.some((c) => c.chainId === chainId));
+    return sequence.network.allNetworks.findIndex((x) => x.chainId === chainId) === -1
+  }
+
+  /**
+   * This patches the Sequence provider to add support for switching chains
+   * we do this by replacing the send/sendAsync methods with our own methods
+   * that intercept `wallet_switchEthereumChain` requests, and forwards everything else.
+   * 
+   * NOTICE: This is a temporary solution until Sequence Wallet supports switching chains
+   * directly from the provider.
+   * 
+   */
+  private patchProvider(provider: sequence.provider.Web3Provider) {
+    // Capture send/sendAsync, replace them with our own
+    // the only difference is that we capture wallet_switchEthereumChain
+    // and call our own switchChain method
+    const send = provider.send.bind(provider)
+    const sendAsync = provider.sendAsync.bind(provider)
+    const switchChain = this.switchChain.bind(this) as (chainId: number) => Promise<Chain>
+
+    provider.send = async (method: string, params: any[], _chainId?: number) => {
+      if (method === 'wallet_switchEthereumChain') {
+        const args = params[0] as { chainId: string } | number | string
+        return switchChain(normalizeChainId(args))
+      }
+
+      if (method === 'eth_chainId') {
+        return this.chainId.get()
+      }
+
+      return send(method, params, this.chainId.get())
+    }
+
+    provider.sendAsync = (
+      request: sequence.network.JsonRpcRequest,
+      callback: sequence.network.JsonRpcResponseCallback | ((error: any, response: any) => void),
+      _chainId?: number
+    ) => {
+      if (request.method === 'wallet_switchEthereumChain') {
+        if (!request.params || request.params.length === 0) {
+          return callback(new Error('Missing chainId'), null)
+        }
+
+        const args = request.params[0] as { chainId: string } | number | string
+        return switchChain(normalizeChainId(args)).then(
+          (chain) => callback(null, { result: chain }),
+          (error) => callback(error, null)
+        )
+      }
+
+      if (request.method === 'eth_chainId') {
+        return callback(null, { result: this.chainId.get() })
+      }
+
+      return sendAsync(request, callback, this.chainId.get())
+    }
+
+    return provider
   }
 }
 
-function normalizeChainId(chainId: string | number | bigint) {
-  if (typeof chainId === 'string') return Number.parseInt(chainId, chainId.trim().substring(0, 2) === '0x' ? 16 : 10);
-  if (typeof chainId === 'bigint') return Number(chainId);
-  return chainId;
+
+function normalizeChainId(chainId: string | number | bigint | { chainId: string }) {
+  if (typeof chainId === 'object') return normalizeChainId(chainId.chainId)
+  if (typeof chainId === 'string') return Number.parseInt(chainId, chainId.trim().substring(0, 2) === '0x' ? 16 : 10)
+  if (typeof chainId === 'bigint') return Number(chainId)
+  return chainId
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,159 +2,205 @@
 # yarn lockfile v1
 
 
-"0xsequence@^0.43.0":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/0xsequence/-/0xsequence-0.43.29.tgz#7d6b2ed546a7b76c0c4acabba920681b24093980"
-  integrity sha512-Kd1pZYFqzbj5LYYxD6MsfRSItdsamPYjBDRiMzyf3CMWgvf4VP57fmxbL5oz245KG5iBOx2NAtuLws4g6Pp7Ww==
+"0xsequence@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/0xsequence/-/0xsequence-1.0.0.tgz#50d9f2a32759b36d8af35060c7da5f07f878b4b6"
+  integrity sha512-P9Bsz1imazNI7lYuy7IjO+0NqAICsemPVZvGvCk0SjauchQL0EAGvwwgdSkzmiEqIBB/hKONXCvaes7V2Nk9wA==
   dependencies:
-    "@0xsequence/abi" "^0.43.29"
-    "@0xsequence/api" "^0.43.29"
-    "@0xsequence/auth" "^0.43.29"
-    "@0xsequence/config" "^0.43.29"
-    "@0xsequence/guard" "^0.43.29"
-    "@0xsequence/indexer" "^0.43.29"
-    "@0xsequence/metadata" "^0.43.29"
-    "@0xsequence/multicall" "^0.43.29"
-    "@0xsequence/network" "^0.43.29"
-    "@0xsequence/provider" "^0.43.29"
-    "@0xsequence/relayer" "^0.43.29"
-    "@0xsequence/transactions" "^0.43.29"
-    "@0xsequence/utils" "^0.43.29"
-    "@0xsequence/wallet" "^0.43.29"
+    "@0xsequence/abi" "1.0.0"
+    "@0xsequence/account" "1.0.0"
+    "@0xsequence/api" "1.0.0"
+    "@0xsequence/auth" "1.0.0"
+    "@0xsequence/core" "1.0.0"
+    "@0xsequence/guard" "1.0.0"
+    "@0xsequence/indexer" "1.0.0"
+    "@0xsequence/metadata" "1.0.0"
+    "@0xsequence/migration" "1.0.0"
+    "@0xsequence/multicall" "1.0.0"
+    "@0xsequence/network" "1.0.0"
+    "@0xsequence/provider" "1.0.0"
+    "@0xsequence/relayer" "1.0.0"
+    "@0xsequence/sessions" "1.0.0"
+    "@0xsequence/signhub" "1.0.0"
+    "@0xsequence/utils" "1.0.0"
+    "@0xsequence/wallet" "1.0.0"
 
-"@0xsequence/abi@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/abi/-/abi-0.43.29.tgz#62f9e7ffd5160372d2e6551879ed3476c6fbc2ae"
-  integrity sha512-tx5rwgkIrNGmvfFPEjm9s0/eX6hyWo90FMCEf1yxLZqjxUIhKS8AJvAvGH4sjmQ5eeAx5ujkE8xNxWEFs6gZPQ==
+"@0xsequence/abi@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/abi/-/abi-1.0.0.tgz#0fee26be7d8734c80bfd05e20773885f7bd4b5a4"
+  integrity sha512-LJR884HKWJc+5iYOotegQ4kMTG33OtsHSW1+6dLbncqlMLNcIe0FA/IazuH1bjYiUrewvhrjJi+lF43dXOrBtw==
 
-"@0xsequence/api@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/api/-/api-0.43.29.tgz#0288e1bf58f67ce1739b08c2f72949e5782ff412"
-  integrity sha512-o/BW/KKX5SG+Rk58J1wv78MmKdW3OEqzcTZJ6isnUOSeG+4NYVrY+RV4r1zwu9BInI54jin2w0UGk9hjp5buqw==
-
-"@0xsequence/auth@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/auth/-/auth-0.43.29.tgz#27e977924479cf1ff69b8891c9e034c3de023cf6"
-  integrity sha512-yX5i5b2tx5a/eF3g8NxkqXYTXa9LSAhDgJQCwFNKa1Trb10Ev3ADj+SlCpkxSpLk8ikUyPkg2ELwf9Usro4v4Q==
+"@0xsequence/account@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/account/-/account-1.0.0.tgz#75f29d6f9f06d3eb5df8b9ee2385b5272374f4ec"
+  integrity sha512-pziQ31I0Ayui8jcdWFBji/QDbl3ozuUKKNkSU9qMuxdyOV6us0MChnlxMdO9xfivWJAIjRaJkTiAvrKg4ZpwBQ==
   dependencies:
-    "@0xsequence/abi" "^0.43.29"
-    "@0xsequence/api" "^0.43.29"
-    "@0xsequence/config" "^0.43.29"
-    "@0xsequence/ethauth" "^0.8.0"
-    "@0xsequence/indexer" "^0.43.29"
-    "@0xsequence/metadata" "^0.43.29"
-    "@0xsequence/network" "^0.43.29"
-    "@0xsequence/provider" "^0.43.29"
-    "@0xsequence/utils" "^0.43.29"
-    "@0xsequence/wallet" "^0.43.29"
+    "@0xsequence/core" "1.0.0"
+    "@0xsequence/migration" "1.0.0"
+    "@0xsequence/network" "1.0.0"
+    "@0xsequence/relayer" "1.0.0"
+    "@0xsequence/sessions" "1.0.0"
+    "@0xsequence/utils" "1.0.0"
+    "@0xsequence/wallet" "1.0.0"
+    ethers "^5.5.2"
 
-"@0xsequence/config@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/config/-/config-0.43.29.tgz#97abaeb2f2e43f6b3960ee84214e907201c75839"
-  integrity sha512-HT63jMmEtM8+fj76oSuCOxiDEUe4pXrFB3FRiA7K+/SHu5JWyRoK3rv9RoEB/MPUpHPcqIBkFtTXaYLjGRe4yg==
+"@0xsequence/api@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/api/-/api-1.0.0.tgz#22f37fa1d8f225a19db2742a617fdaa24ebfb6b3"
+  integrity sha512-WfrI3NQwxvflFFu5WP4qwqHmUXEc+3jlgNss2MmrDvljyyGOrryrMsnUU502MRQGsc7XZaMI9QmDOEbfhTLSbw==
+
+"@0xsequence/auth@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/auth/-/auth-1.0.0.tgz#af40f60fc8dcea8ce08dae1a018e56dc42a24c04"
+  integrity sha512-oJFo5RpdiXHtke2Luk/+BfF3MONkXlX+Rp9O6DluiQN7ZIS6mboN2DfEcbi/rLoZpcI/lQem6Bqb3dQ6D0zRfQ==
   dependencies:
-    "@0xsequence/abi" "^0.43.29"
-    "@0xsequence/multicall" "^0.43.29"
-    "@0xsequence/network" "^0.43.29"
-    "@0xsequence/utils" "^0.43.29"
+    "@0xsequence/abi" "1.0.0"
+    "@0xsequence/account" "1.0.0"
+    "@0xsequence/api" "1.0.0"
+    "@0xsequence/core" "1.0.0"
+    "@0xsequence/ethauth" "^0.8.1"
+    "@0xsequence/indexer" "1.0.0"
+    "@0xsequence/metadata" "1.0.0"
+    "@0xsequence/migration" "1.0.0"
+    "@0xsequence/network" "1.0.0"
+    "@0xsequence/sessions" "1.0.0"
+    "@0xsequence/signhub" "1.0.0"
+    "@0xsequence/utils" "1.0.0"
+    "@0xsequence/wallet" "1.0.0"
 
-"@0xsequence/ethauth@^0.8.0":
+"@0xsequence/core@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/core/-/core-1.0.0.tgz#86b3ad7f007f90a584e07f2a34832552e7d944bb"
+  integrity sha512-457Kop4frYkHesTRzOIciHJS3uIoXiVBcbJ/dP1c78ne7wZSccdcCmd6MrjjzYuywNS0rTG/nkHHj8xO89fwgg==
+  dependencies:
+    "@0xsequence/abi" "1.0.0"
+
+"@0xsequence/ethauth@^0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@0xsequence/ethauth/-/ethauth-0.8.1.tgz#9b97a17e74ca9559b79a93a8e39ca77baaccc943"
   integrity sha512-P21cxRSS+2mDAqFVAJt0lwQFtbObX+Ewlj8DMyDELp81+QbfHFh6LCyu8dTXNdBx6UbmRFOCSBno5Txd50cJPQ==
   dependencies:
     js-base64 "^3.7.2"
 
-"@0xsequence/guard@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/guard/-/guard-0.43.29.tgz#1f13b1266b7e450f86dc5e47462ca0ee4360e584"
-  integrity sha512-IZ40BoChB/ws09NbSzytOi/8xojsR3g8sgwzZ/eth6YWeMP1MIuZc2BjRDAc59oStkspZxguWnE4HgVibTBHug==
-
-"@0xsequence/indexer@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/indexer/-/indexer-0.43.29.tgz#0da88058bdaf1b66613767c31ce002efede70239"
-  integrity sha512-Myx/2D+vcoY/cPYKIqoB1VyALo4e4P3KQsOWxkb6o2JADOntY0mcFq9YIMPl+Zj1xPkGHTCNIk2p1udKMhbKzQ==
-
-"@0xsequence/metadata@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/metadata/-/metadata-0.43.29.tgz#5962014794e5942b890aefb6e2b917da7c9e70f0"
-  integrity sha512-wk15QFMaz0h0kNP2W9Ms1rVykG6N/tPzRdhqvBviq2vROZFHmBwq7TbWae4t/gIeoo+1FZI5507771edJ8KJaw==
-
-"@0xsequence/multicall@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/multicall/-/multicall-0.43.29.tgz#5f1e06a2388432176db0cc4c56d94fbb0c89ed4c"
-  integrity sha512-7kV3koB0aaLHjJjjoxIYhk8R/40WMIFOzJNZSRnzmeSKf67hvQNw9rkZwr0qx3B11IPANfZnmhs2gOnybAbiBQ==
+"@0xsequence/guard@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/guard/-/guard-1.0.0.tgz#cc2108b4cd63dbe8b739a7d6039899ad4d44dea5"
+  integrity sha512-WXBCphl4FoNzBtKthxkw90NAeg78VGD8KWzuiRWmw9H91okGxuLEJmi7xxqNgcmkPa+HwDbnLR7LosjO+ocCMw==
   dependencies:
-    "@0xsequence/abi" "^0.43.29"
-    "@0xsequence/network" "^0.43.29"
-    "@0xsequence/utils" "^0.43.29"
+    "@0xsequence/core" "1.0.0"
+    "@0xsequence/signhub" "1.0.0"
+    ethers "^5.7.2"
 
-"@0xsequence/network@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/network/-/network-0.43.29.tgz#00a6688f64512fc7dbe885a33795f7c17d7f4682"
-  integrity sha512-0CmgIpmfOVOmqzIbaDg8hzRc7aR/z2Lx4wwrqEAsfsggp7+y6mwm8rSda4Z6ZOtlBeWSod9w+x3AqpL8iZenYg==
-  dependencies:
-    "@0xsequence/indexer" "^0.43.29"
-    "@0xsequence/provider" "^0.43.29"
-    "@0xsequence/relayer" "^0.43.29"
-    "@0xsequence/utils" "^0.43.29"
+"@0xsequence/indexer@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/indexer/-/indexer-1.0.0.tgz#a21062e655aa633452528c3d6b05f441d311d24f"
+  integrity sha512-EIBC2fhK80yAyUwLMFQ2R9WAXM5uZiQ9/3EuaA+Mqb60LFc/h58HXXTRXJ7fU82+fTbPPQt7cPDYMFfGMgL2wg==
 
-"@0xsequence/provider@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/provider/-/provider-0.43.29.tgz#310177fa50f984efb093460777db152272c2d54b"
-  integrity sha512-ZfKMh8YgtRcJ9gt5PChHjGA11R226IRjA5UjYHBYOSywcQxTUjpyEMrCEfFQ5x9n8X3MVF+0RJaFbPFs6FyDxg==
+"@0xsequence/metadata@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/metadata/-/metadata-1.0.0.tgz#a1d4ec019c1a9b1b118dee2ad8ef6d4c20fc907c"
+  integrity sha512-+lwg0KkNHCpLH4/Tvn45AWj+FNivXNX/fsbhDF4CMOvwTn/IsX1HgPtS2ipGORTfEROwFBhMLhfJsZuA9r5X8A==
+
+"@0xsequence/migration@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/migration/-/migration-1.0.0.tgz#040002a22f23ad7de6366d5ee41ca25bc5d471f9"
+  integrity sha512-CwpcPUS7JE16YsF6sdpR2WqnWJjIPx8oLTUMN4tCihM6V6jOLsCYrfYvaY1Y+VgDq31i8DrGwEluTma6XVnDnQ==
   dependencies:
-    "@0xsequence/abi" "^0.43.29"
-    "@0xsequence/auth" "^0.43.29"
-    "@0xsequence/config" "^0.43.29"
-    "@0xsequence/network" "^0.43.29"
-    "@0xsequence/relayer" "^0.43.29"
-    "@0xsequence/transactions" "^0.43.29"
-    "@0xsequence/utils" "^0.43.29"
-    "@0xsequence/wallet" "^0.43.29"
+    "@0xsequence/abi" "1.0.0"
+    "@0xsequence/core" "1.0.0"
+    "@0xsequence/wallet" "1.0.0"
+    ethers "^5.5.2"
+
+"@0xsequence/multicall@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/multicall/-/multicall-1.0.0.tgz#33eb9ecb7cf49820130fbfc96fa9573a42d6ac25"
+  integrity sha512-uLGdWaLmVAwi6yUWmzn7EEWHJHj4HcasFKY2LqvWCav3QhzFQy7ky2flnkOV8qt/iqorDyhC3uGs90oGRK+MYA==
+  dependencies:
+    "@0xsequence/abi" "1.0.0"
+    "@0xsequence/network" "1.0.0"
+    "@0xsequence/utils" "1.0.0"
+
+"@0xsequence/network@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/network/-/network-1.0.0.tgz#255a8e6b8a3eeea550347a36fb4c8d7dca435db7"
+  integrity sha512-OoRqEGPgucP9TYcCojGe+V5nyds8DAScGJwfEYqxVCr9Ddc8+RjmVuU0kQ7dAzHNSlcFrTBMUVpQQdhz4uLMfg==
+  dependencies:
+    "@0xsequence/core" "1.0.0"
+    "@0xsequence/indexer" "1.0.0"
+    "@0xsequence/relayer" "1.0.0"
+    "@0xsequence/utils" "1.0.0"
+
+"@0xsequence/provider@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/provider/-/provider-1.0.0.tgz#6b603b8a89d22514ebbb67bcf6e85e6d4faaabe1"
+  integrity sha512-b4BubxoRvvcuxvA9eoZxITv++Ed2Pt5HX1Qlps0U22YIeZxfRVLEnpQJl6beuJUobrY2VYQcqWyazEc/ylv95A==
+  dependencies:
+    "@0xsequence/abi" "1.0.0"
+    "@0xsequence/account" "1.0.0"
+    "@0xsequence/auth" "1.0.0"
+    "@0xsequence/core" "1.0.0"
+    "@0xsequence/migration" "1.0.0"
+    "@0xsequence/network" "1.0.0"
+    "@0xsequence/relayer" "1.0.0"
+    "@0xsequence/utils" "1.0.0"
+    "@0xsequence/wallet" "1.0.0"
     eventemitter2 "^6.4.5"
     webextension-polyfill "^0.10.0"
 
-"@0xsequence/relayer@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/relayer/-/relayer-0.43.29.tgz#03358905d1654d76e854b2756025dab1ac9a02c8"
-  integrity sha512-Yp1mrOvhzMLvrvLoxrH+qHo6kp6LEzTLzF0NYzM/j7wVKdY0FBOEHEO6sSCVNrSOv8YRDRjtnz/3K7Sh3eweXw==
+"@0xsequence/relayer@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/relayer/-/relayer-1.0.0.tgz#b0103e48f6fcc07435edb0cd1294b62258747abc"
+  integrity sha512-FrgkCn4+jPoo50Vq/+opMmyoMhK6LOR2PqaXjX7mGnbSrs8DaBhdBzcZydYecV+xX5ryoEgD9F0mY2HlZ0PC9w==
   dependencies:
-    "@0xsequence/abi" "^0.43.29"
-    "@0xsequence/config" "^0.43.29"
-    "@0xsequence/network" "^0.43.29"
-    "@0xsequence/transactions" "^0.43.29"
-    "@0xsequence/utils" "^0.43.29"
+    "@0xsequence/abi" "1.0.0"
+    "@0xsequence/core" "1.0.0"
+    "@0xsequence/utils" "1.0.0"
 
-"@0xsequence/transactions@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/transactions/-/transactions-0.43.29.tgz#cd0503df052cf5df2b99e3496444b8efe5cd4186"
-  integrity sha512-htJ+vY372Yfe9ojufP2KzJRXaL9cnWGTP+dZD3KAp47AJbCfcf44/ggqL6rLzCFhQSqF3e6m2BoBNA2GvIsilQ==
+"@0xsequence/replacer@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/replacer/-/replacer-1.0.0.tgz#f9981a9fd0d9a75dd1616215107b0ef5fe88c1e4"
+  integrity sha512-xT8hLhzinlV2H+fTg0oUHhR1E/D8sXB66V30lswER6F0z42wc2RM9yivHA7zQVYTujvF17D/uKlGuGQZsYN/Cw==
   dependencies:
-    "@0xsequence/abi" "^0.43.29"
-    "@0xsequence/config" "^0.43.29"
-    "@0xsequence/network" "^0.43.29"
-    "@0xsequence/utils" "^0.43.29"
+    "@0xsequence/abi" "1.0.0"
+    "@0xsequence/core" "1.0.0"
 
-"@0xsequence/utils@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/utils/-/utils-0.43.29.tgz#86e1a44e8cb006989e8e2daae9fb573e3cc32442"
-  integrity sha512-5GVIIoxlGESZ+GIPn/0IKu4oTcPTpteDbks4dKjfL+jF/jogZB7qWIWUpOF3O0wgZO5xbimZIur6GowcQq8aLw==
+"@0xsequence/sessions@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/sessions/-/sessions-1.0.0.tgz#d3feb160a1b5927a952d8b378ce563553e7f775e"
+  integrity sha512-fX+I7+A5ZK9VCqpJiAKTQn7ZZdXa4ms/ED4ouHlEBDrgJPU1XaSgzCu7H8x4qFBz48l7yoVC6WQUzDKHNzHyow==
+  dependencies:
+    "@0xsequence/core" "1.0.0"
+    "@0xsequence/migration" "1.0.0"
+    "@0xsequence/replacer" "1.0.0"
+    ethers "^5.5.2"
+    idb "^7.1.1"
+
+"@0xsequence/signhub@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/signhub/-/signhub-1.0.0.tgz#ea0240b556f1fe63881f00d5203fbbb4ef770b29"
+  integrity sha512-w50D+mlxnhvlydKKlQFNE9olcdKXZEXPJK1iVWsoxiMYelAnL7bkqqakKAAR873t4MJd/BVnNoSlzODBI/vJZw==
+  dependencies:
+    ethers "^5.5.2"
+
+"@0xsequence/utils@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/utils/-/utils-1.0.0.tgz#96169be2f2aa82ab16a20911733c57b8548c5762"
+  integrity sha512-sEvTh/Sc60h+SzZQV9X3WV7q0kEa2hYSUz5riOL2LW4DX++DX31aisgYVn8VhbcNpFaEV7FYYq/tTFyWemJcjQ==
   dependencies:
     js-base64 "^3.7.2"
 
-"@0xsequence/wallet@^0.43.29":
-  version "0.43.29"
-  resolved "https://registry.yarnpkg.com/@0xsequence/wallet/-/wallet-0.43.29.tgz#9fbecbaf9a92c023d3940619da775fa9572f1307"
-  integrity sha512-TBx+tQK/hM7QgfKdC+PtrEGNGsTHhEKmvbt7kiVzikKRcP5lWmQRfb2wrHds6/RpRvEUBg9yoUEGMdqCW+JjiQ==
+"@0xsequence/wallet@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@0xsequence/wallet/-/wallet-1.0.0.tgz#959d8ad151848102c8f3ce0815663e40f2d80d3b"
+  integrity sha512-OsVqsSxOe7n4P6J+/yb9TnwSSvb9ve7+f8RDBmTL7HpxxjvIGpVB4lMVNULWZxF0b880gFQUuTTjY9D987THag==
   dependencies:
-    "@0xsequence/abi" "^0.43.29"
-    "@0xsequence/config" "^0.43.29"
-    "@0xsequence/guard" "^0.43.29"
-    "@0xsequence/network" "^0.43.29"
-    "@0xsequence/relayer" "^0.43.29"
-    "@0xsequence/transactions" "^0.43.29"
-    "@0xsequence/utils" "^0.43.29"
+    "@0xsequence/abi" "1.0.0"
+    "@0xsequence/core" "1.0.0"
+    "@0xsequence/guard" "1.0.0"
+    "@0xsequence/network" "1.0.0"
+    "@0xsequence/relayer" "1.0.0"
+    "@0xsequence/signhub" "1.0.0"
+    "@0xsequence/utils" "1.0.0"
 
 "@adraffy/ens-normalize@1.9.0":
   version "1.9.0"
@@ -2120,7 +2166,7 @@ eth-rpc-errors@^4.0.2:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
-ethers@^5.7.2:
+ethers@^5.5.2, ethers@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -2356,6 +2402,11 @@ humanize-ms@^1.2.1:
   integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
   dependencies:
     ms "^2.0.0"
+
+idb@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-7.1.1.tgz#d910ded866d32c7ced9befc5bfdf36f572ced72b"
+  integrity sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==
 
 ieee754@^1.2.1:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,6 +1240,11 @@
   resolved "https://registry.yarnpkg.com/@wagmi/chains/-/chains-0.3.1.tgz#5d8e8ef1bcd8637c9f3ead8626595b12a01c35e4"
   integrity sha512-NN5qziBLFeXnx0+3ywdiKKXUSW4H73Wc1jRrygl9GKXVPawU0GBMudwXUfV7VOu6E9vmG7Arj0pVsEwq63b2Ew==
 
+"@wagmi/chains@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@wagmi/chains/-/chains-1.2.0.tgz#d59eaa70ec51a5fdcd113975926992acfb17ab12"
+  integrity sha512-dmDRipsE54JfyudOBkuhEexqQWcrZqxn/qiujG8SBzMh/az/AH5xlJSA+j1CPWTx9+QofSMF3B7A4gb6XRmSaQ==
+
 "@wagmi/connectors@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@wagmi/connectors/-/connectors-2.0.0.tgz#558a7bc8b2d5f08a2c10fd14b3126adad12d1717"
@@ -1631,6 +1636,11 @@ abitype@0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.8.1.tgz#9575a21da88bb4094a262a653e526a088ab06041"
   integrity sha512-n8Di6AWb3i7HnEkBvecU6pG0a5nj5YwMvdAIwPLsQK95ulRy/XS113s/RXvSfTX1iOQJYFrEO3/q4SMWu7OwTA==
+
+abitype@0.8.11:
+  version "0.8.11"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.8.11.tgz#66e1cf2cbf46f48d0e57132d7c1c392447536cc1"
+  integrity sha512-bM4v2dKvX08sZ9IU38IN5BKmN+ZkOSd2oI4a9f0ejHYZQYV6cDr7j+d95ga0z2XHG36Y4jzoG5Z7qDqxp7fi/A==
 
 abitype@0.8.2:
   version "0.8.2"
@@ -3399,18 +3409,18 @@ valtio@1.10.5:
     proxy-compare "2.5.1"
     use-sync-external-store "1.2.0"
 
-viem@^0.3.37:
-  version "0.3.37"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-0.3.37.tgz#0426863c52f4b77547bd3216b8ac66e32a38dda5"
-  integrity sha512-17jycP/1Hy9DsDpHlaaI7bbAHBDYGfVYHN6j0ltE7A/S30RXhPVFe4LAPRfmG+xR2QBq8xSUpjO78cRgDLBjZQ==
+viem@^1.2.14:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-1.2.14.tgz#f3d3f2262c420336a1aa453f50e1d8b1834df289"
+  integrity sha512-Hak+NGxdm+vRyt/cV8NbTlW1IRPKAmJBCx1SZZIc1uNVA/Rs6eN0Nh7mB8MbmA3FLJ0ymD/dSbB4MI9GGbGCgA==
   dependencies:
     "@adraffy/ens-normalize" "1.9.0"
     "@noble/curves" "1.0.0"
     "@noble/hashes" "1.3.0"
     "@scure/bip32" "1.3.0"
     "@scure/bip39" "1.2.0"
-    "@wagmi/chains" "0.3.1"
-    abitype "0.8.2"
+    "@wagmi/chains" "1.2.0"
+    abitype "0.8.11"
     isomorphic-ws "5.0.0"
     ws "8.12.0"
 


### PR DESCRIPTION
This updates rainbowkit to sequence.js 1.0.0, and also implements network switching. The network switching is handled completely client side, sequence.js 1.0.0 doesn't allow any other way.

The network switching makes use of a singleton, this is implemented this way because rainbowkit expects all connectors to be talking to he same wallet, and thus all connectors to reflect any network change. Because we can't control this, we need to use a singleton to keep a shared state.  