### PR TITLE
Use EIP6492 only when account has suffix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './sequence-wallet';
+export * from './utils';

--- a/src/sequence-connector.ts
+++ b/src/sequence-connector.ts
@@ -209,15 +209,18 @@ export class SequenceConnector extends Connector<sequence.provider.Web3Provider,
       method: string,
       params: any[] | undefined,
       _chainId?: number
-    ): Promise<{ cont: true } | { cont: false, res: any }> => {
+    ): Promise<
+      { continue: true, method: string, params: any[] | undefined } |
+      { continue: false, result: any }
+    > => {
       if (method === 'wallet_switchEthereumChain') {
         if (!params) throw new Error('Missing params')
         const args = params[0] as { chainId: string } | number | string
-        return { cont: false, res: switchChain(normalizeChainId(args)) }
+        return { continue: false, result: switchChain(normalizeChainId(args)) }
       }
 
       if (method === 'eth_chainId') {
-        return { cont: false, res: this.chainId.get() }
+        return { continue: false, result: this.chainId.get() }
       }
 
       // Use sequence signing methods instead for 6492 support
@@ -231,17 +234,18 @@ export class SequenceConnector extends Connector<sequence.provider.Web3Provider,
           method = method === 'personal_sign' ? 'sequence_sign' : 'sequence_signTypedData_v4'
         }
       }
-      return { cont: true }
+
+      return { continue: true, method, params }
     }
 
     provider.send = async (method: string, params: any[], _chainId?: number) => {
       const altRes = await altSend(method, params, _chainId)
   
-      if (!altRes.cont) {
-        return altRes.res
+      if (!altRes.continue) {
+        return altRes.result
       }
   
-      return send(method, params, this.chainId.get())
+      return send(altRes.method, altRes.params!, this.chainId.get())
     }
 
     provider.sendAsync = (
@@ -250,10 +254,10 @@ export class SequenceConnector extends Connector<sequence.provider.Web3Provider,
       _chainId?: number
     ) => {
       altSend(request.method, request.params, _chainId).then((altRes) => {
-        if (!altRes.cont) {
-          return callback(null, { result: altRes.res })
+        if (!altRes.continue) {
+          return callback(null, { result: altRes.result })
         } else {
-          return sendAsync(request, callback, this.chainId.get())
+          return sendAsync(altRes, callback, this.chainId.get())
         }
       }).catch((err) => {
         callback(err, null)

--- a/src/sequence-connector.ts
+++ b/src/sequence-connector.ts
@@ -225,9 +225,9 @@ export class SequenceConnector extends Connector<sequence.provider.Web3Provider,
 
       // Use sequence signing methods instead for 6492 support
       // but only if the signing account is suffixed with :EIP6492 (utils.usingEIP6492)
-      if (method === 'personal_sign' || method === 'eth_signTypedData') {
+      if (method === 'personal_sign' || method === 'eth_signTypedData' || method === 'eth_signTypedData_v4') {
         if (!params) throw new Error('Missing params')
-        const { EIP6492 } = usesEIP6492Account(params[0])
+        const { EIP6492 } = usesEIP6492Account(params[1])
         if (EIP6492) {
           // Only override the method if the account is suffixed with :EIP6492
           // otherwise default to the original behavior

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,8 @@
+
+export function usingEIP6492(account: `0x${string}`): `0x${string}` {
+  return account + `:EIP6492` as `0x${string}`
+}
+
+export function usesEIP6492Account(account: `0x${string}`): { EIP6492: boolean, account: `0x${string}` } {
+  return { EIP6492: account.endsWith(':EIP6492'), account: account.replace(':EIP6492', '') as `0x${string}` }
+}


### PR DESCRIPTION
This would be used as such:

<img width="558" alt="Screenshot 2023-07-14 at 09 19 07" src="https://github.com/0xsequence/rainbowkit-plugin/assets/12701942/0eb1c6f0-821e-45f3-893d-98cd6e8dc72a">

It's a more hacky of a solution, but it does enable the dapp to sign both EIP6492 and nonEIP6492 signatures without reconnecting the wallet.

I also did the following change:
- Removed the patch provider duplicated logic